### PR TITLE
patch: latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM mcr.microsoft.com/mssql/server:2019-latest
+FROM mcr.microsoft.com/mssql/server:2022-latest
 LABEL maintainer="Zack Moore https://github.com/ormico/"
 USER root
 VOLUME download
+ENV ACCEPT_EULA=Y
 RUN apt-get update \
     && apt-get upgrade -y \
-    && ACCEPT_EULA=Y apt-get install -y \
+    && apt-get install -y \
         unzip \
-        msodbcsql17 \
+        msodbcsql18 \
         mssql-tools
 RUN wget -O sqlpackage.zip https://aka.ms/sqlpackage-linux \
     && unzip sqlpackage.zip -d /opt/sqlpackage \
     && chmod +x /opt/sqlpackage/sqlpackage \
     && rm /sqlpackage.zip
-RUN wget "http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.10_amd64.deb" \
-    && dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.10_amd64.deb
+RUN wget "http://ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb" \
+    && dpkg -i libssl1.1_1.1.1w-0+deb11u1_amd64.deb
 #USER mssql
 ENV PATH=$PATH:/opt/mssql-tools/bin:/opt/sqlpackage


### PR DESCRIPTION
I was kind of hoping that latest sqlpackage would work automatically with managed identity, it didn't but at least this is now build-able and patched to the latest versions.