### PR TITLE
update libssl to 3.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN wget -O sqlpackage.zip https://aka.ms/sqlpackage-linux \
     && unzip sqlpackage.zip -d /opt/sqlpackage \
     && chmod +x /opt/sqlpackage/sqlpackage \
     && rm /sqlpackage.zip
-RUN wget "http://ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb" \
-    && dpkg -i libssl1.1_1.1.1w-0+deb11u1_amd64.deb
+RUN wget "http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl3_3.1.4-2_amd64.deb" \
+    && dpkg -i libssl3_3.1.4-2_amd64.deb \
+    && rm libssl3_3.1.4-2_amd64.deb
 #USER mssql
 ENV PATH=$PATH:/opt/mssql-tools/bin:/opt/sqlpackage


### PR DESCRIPTION
fixes #6 

I updated to latest libssl and container builds locally, and I can log in, create a db on the local sql instance with sqlcmd, but when I try to export using sqlpackage I get the following error and not log file is created.

```
# sqlpackage /a:Export /ssn:localhost,1433 /sdn:testdb1 /su:sa "/sp:*****" /tf:testdb1.bacpac /SourceTrustServerCertificate:True /df:sp.log
Connecting to database 'testdb1' on server 'localhost,1433'.
Extracting schema
Extracting schema from database
*** Error exporting database:Could not extract package from specified database.
Unable to reconnect to database: A transport-level error has occurred when sending the request to the server. (provider: TCP Provider, error: 35 - An internal exception was caught)
A transport-level error has occurred when sending the request to the server. (provider: TCP Provider, error: 35 - An internal exception was caught)
Unable to write data to the transport connection: Connection reset by peer.
Connection reset by peer
Time elapsed 0:02:27.20
```

I'm checking in my progress here for now and will revisit later.

I did not go back and run this same test on previous version or try connecting to a different sql instance.